### PR TITLE
Maktest: Watch test4

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -21980,3 +21980,4 @@
 1595012145	Daniil	test\.com
 1595013296	Makyen	test1
 1595013303	Makyen	test1a\.com
+1595014127	Maktest	test4


### PR DESCRIPTION
[Maktest](https://chat.stackexchange.com/users/344396) requests the watch of the watch_keyword `test4`. See the MS search [here](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%28%3Fs%3A%5Cbtest4%5Cb%29) and the Stack Exchange search [in text](https://stackexchange.com/search?q=%22test4%22), [in URLs](https://stackexchange.com/search?q=url%3A%22test4%22), and [in code](https://stackexchange.com/search?q=code%3A%22test4%22).
<!-- METASMOKE-BLACKLIST-WATCH_KEYWORD test4 -->