### PR TITLE
Maktest: Blacklist test6

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -2314,3 +2314,4 @@ barx[\W_]*+buddy(?:[\W_]*+(?:review|\d++|[\da-f]{4,}+))*
 knightwood
 fyers[\W_]*+demat(?:[\W_]*+(?:account|free|investment|online|trading|platform)s?)*
 test2
+test6


### PR DESCRIPTION
[Maktest](https://chat.stackexchange.com/users/344396) requests the blacklist of the keyword `test6`. See the MS search [here](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%28%3Fs%3A%5Cbtest6%5Cb%29) and the Stack Exchange search [in text](https://stackexchange.com/search?q=%22test6%22), [in URLs](https://stackexchange.com/search?q=url%3A%22test6%22), and [in code](https://stackexchange.com/search?q=code%3A%22test6%22).
<!-- METASMOKE-BLACKLIST-KEYWORD test6 -->