### PR TITLE
Maktest: Blacklist test7\.com

### DIFF
--- a/blacklisted_websites.txt
+++ b/blacklisted_websites.txt
@@ -3661,3 +3661,4 @@ classifieds\.usatoday\.com
 infocampus\.co\.in
 ghostrifles\.com
 test2a\.com
+test7\.com


### PR DESCRIPTION
[Maktest](https://chat.stackexchange.com/users/344396) requests the blacklist of the website `test7\.com`. See the MS search [here](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=test7%5C.com) and the Stack Exchange search [in text](https://stackexchange.com/search?q=%22test7.com%22), [in URLs](https://stackexchange.com/search?q=url%3A%22test7.com%22), and [in code](https://stackexchange.com/search?q=code%3A%22test7.com%22).
<!-- METASMOKE-BLACKLIST-WEBSITE test7\.com -->